### PR TITLE
Initialize setupTasks property in config object

### DIFF
--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -92,6 +92,7 @@ export default (path = SfProject.resolveProjectPathSync()): Config => {
       (isWsl && defaults.puppeteerWSL) ||
       (isDocker() && defaults.puppeteerDocker) ||
       defaults.puppeteer,
+    setupTasks: configFromFile?.setupTasks,
   };
 
   resolvedConfigs[path] = config;


### PR DESCRIPTION
Currently when running `sf org configure` no tasks are executed because the `setupTasks` property is never set on the config object.

This PR initializes that property so that this commands actually does something.